### PR TITLE
Convert html parsed data to string with html method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 1.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Convert html parsed data to string with html method.
+  [rodfersou]
 
 
 1.0.0 (2019-02-23)

--- a/src/collective/embeddedpage/browser/embeddedpage.py
+++ b/src/collective/embeddedpage/browser/embeddedpage.py
@@ -21,5 +21,5 @@ class EmbeddedPageView(BrowserView):
         el = lxml.html.fromstring(content)
         if el.find('body'):
             el = el.find('body')
-        self.embeddedpage = etree.tostring(el)
+        self.embeddedpage = etree.tostring(el, method='html')
         return self.template()


### PR DESCRIPTION
This change fix the escape of characters into javascript code:
before:
```javascript
$('#demo').html( '&lt;table cellpadding=\'0\' cellspacing=\'0\' border=\'0\' class=\'display\' id=\'example\'&gt;&lt;/table&gt;' );
```
after:
```javascript
$('#demo').html( '<table cellpadding=\'0\' cellspacing=\'0\' border=\'0\' class=\'display\' id=\'example\'></table>' );
```