### PR TITLE
Fix http header forwarding

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@ Changelog
 1.2.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Change header forwarding: Only forward http x-* headers and convert
+  zopes header names (e.g. HTTP_X_FORWARD_FOR to x-forward-for)
+  [csenger]
 
 
 1.2.2 (2019-05-28)

--- a/src/collective/embeddedpage/tests/test_browser_embeddedpage.py
+++ b/src/collective/embeddedpage/tests/test_browser_embeddedpage.py
@@ -185,7 +185,7 @@ class EmbeddedPageViewIntegrationTest(unittest.TestCase):
                 '''
             }
         with HTTMock(response_link):
-            self.request.environ['X-Forwarded-For'] = '1.2.3.4'
+            self.request.environ['HTTP_X_FORWARDED_FOR'] = '1.2.3.4'
             self.get_parsed_data()
         self.assertEquals(
             self.request.response.headers['x-forwarded-for'], '1.2.3.4')


### PR DESCRIPTION
* forward only X-* headers. Some headers break the page (like
  forwarding content-encoding or content-length) or are problematic
  (e.g. set cookie headers)
* Convert from header names in zopes HTTPRequest.environ to the original
  http header name